### PR TITLE
Global via the theme object

### DIFF
--- a/src/__tests__/styleSheet.spec.js
+++ b/src/__tests__/styleSheet.spec.js
@@ -48,4 +48,46 @@ describe('styleSheet.js', () => {
       });
     });
   });
+
+  describe('theme overrides', () => {
+    describe('with a simple rule', () => {
+      let styleSheet;
+
+      function createSimpleRule() {
+        return {
+          bar: {
+            color: 'red',
+            width: 100,
+          },
+        };
+      }
+
+      beforeEach(() => {
+        styleSheet = createStyleSheet('foo', () => createSimpleRule());
+      });
+
+      it('should return the simple rule with no overrides', () => {
+        assert.deepEqual(styleSheet.createRules(), createSimpleRule());
+      });
+
+      it('should return the simple rule with overrides', () => {
+        const overrides = {
+          foo: {
+            bar: {
+              color: 'blue',
+            },
+          },
+        };
+
+        const expectedRules = createSimpleRule();
+
+        expectedRules.bar.color = 'blue';
+
+        assert.deepEqual(
+          styleSheet.createRules({ overrides }),
+          expectedRules
+        );
+      });
+    });
+  });
 });

--- a/src/styleSheet.js
+++ b/src/styleSheet.js
@@ -2,7 +2,7 @@
 
 export function createStyleSheet(
   name: string,
-  callback: (theme: Object) => Object|Object,
+  callback: Object|((theme: Object) => Object),
   options: Object = {}
 ): ThemeReactorStyleSheet {
   const styleSheet = {
@@ -11,12 +11,21 @@ export function createStyleSheet(
     createRules,
   };
 
-  function createRules(theme: Object): Object {
-    if (typeof callback === 'function') {
-      return callback(theme);
+  function createRules(theme: Object = {}): Object {
+    const rules = typeof callback === 'function' ? callback(theme) : callback;
+
+    if (!theme.overrides || !theme.overrides[name]) {
+      return rules;
     }
 
-    return callback;
+    const overrides = theme.overrides[name];
+    const rulesWithOverrides = {};
+
+    Object.keys(rules).forEach((n) => {
+      rulesWithOverrides[n] = Object.assign({}, rules[n], overrides[n]);
+    });
+
+    return rulesWithOverrides;
   }
 
   return styleSheet;


### PR DESCRIPTION
@kof

This lets you pass in overrides on `theme.overrides[SHEET_NAME]` keyed by rule that get automatically copied into sheet rules.

This should be good for the time being, but let me know if you have a better idea.