### PR TITLE
Pick up style nodes properly when stylemanager is initialized

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jss-theme-reactor-build",
   "description": "Powerful theming layer for use with the JSS library (CSS in JS)",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.9.0-alpha.1",
   "scripts": {
     "build": "babel src --ignore *.spec.js --out-dir build && babel-node scripts/copy-files.js",
     "build-publish": "npm run build && cd build && npm publish && cd .. && npm run clean",

--- a/src/__tests__/styleManager.spec.js
+++ b/src/__tests__/styleManager.spec.js
@@ -84,7 +84,7 @@ describe('styleManager.js', () => {
       assert.strictEqual(styleManager.sheetMap.length, 0, 'should empty the sheetmap');
     });
 
-    describe('webpack 1.x hmr support (new styleSheet Object reference)', () => {
+    describe('new styleSheet Object reference', () => {
       it('should replace the stylesheet', () => {
         const styleSheet1Reloaded = createStyleSheet('foo', () => ({
           base: {

--- a/src/__tests__/styleManager.spec.js
+++ b/src/__tests__/styleManager.spec.js
@@ -84,7 +84,7 @@ describe('styleManager.js', () => {
       assert.strictEqual(styleManager.sheetMap.length, 0, 'should empty the sheetmap');
     });
 
-    describe('hmr support (new styleSheet Object reference)', () => {
+    describe('webpack 1.x hmr support (new styleSheet Object reference)', () => {
       it('should replace the stylesheet', () => {
         const styleSheet1Reloaded = createStyleSheet('foo', () => ({
           base: {

--- a/src/styleManager.js
+++ b/src/styleManager.js
@@ -1,5 +1,4 @@
 // @flow
-
 import jssVendorPrefixer from 'jss-vendor-prefixer';
 import type { Rule } from 'jss/lib/types';
 import createHash from 'murmurhash-js/murmurhash3_gc';
@@ -82,6 +81,13 @@ export function createStyleManager({ jss, theme = {} }: StyleManagerOptions = {}
    */
   function renderNew(styleSheet: ThemeReactorStyleSheet): Object {
     const { name, createRules, options } = styleSheet;
+
+    if (typeof window === 'object' && typeof document === 'object') {
+      const element = document.querySelector(`style[data-jss][data-meta="${name}"]`);
+      if (element) {
+        options.element = element;
+      }
+    }
 
     const rules = createRules(styleManager.theme);
     const jssOptions = {

--- a/test/integration/basicUsage.test.js
+++ b/test/integration/basicUsage.test.js
@@ -56,7 +56,7 @@ describe('basic usage', () => {
 
       assert.strictEqual(
         styleElement.getAttribute('data-meta'),
-        'button',
+        `button-${themeObj.id}`,
         'should have the stylesheet name as the data-meta attribute',
       );
 

--- a/test/integration/react.test.js
+++ b/test/integration/react.test.js
@@ -42,7 +42,7 @@ describe('react component integration', () => {
 
       assert.strictEqual(
         styleElement.getAttribute('data-meta'),
-        'button',
+        `button-${theme.id}`,
         'should have the stylesheet name as the data-meta attribute',
       );
 

--- a/test/integration/ssr.test.js
+++ b/test/integration/ssr.test.js
@@ -81,7 +81,7 @@ describe('ssr', () => {
     function createStyleNode(name) {
       const element = document.createElement('style');
       element.setAttribute('data-jss', '');
-      element.setAttribute('data-meta', name);
+      element.setAttribute('data-meta', `${name}-${styleManager.theme.id}`);
       return element;
     }
 
@@ -105,11 +105,11 @@ describe('ssr', () => {
 
     it('should re-use the existing style node', () => {
       styleManager.render(styleSheet);
+      assert.strictEqual(document.head.querySelectorAll('style').length, 4);
       assert.strictEqual(
         styleManager.sheetMap[0].jssStyleSheet.options.element,
         styleNode,
       );
-      assert.strictEqual(document.head.querySelectorAll('style').length, 4);
     });
   });
 });

--- a/test/integration/ssr.test.js
+++ b/test/integration/ssr.test.js
@@ -1,72 +1,115 @@
 /* eslint-env mocha */
 import { assert } from 'chai';
 import { create as createJss } from 'jss';
-import VirtualRenderer from 'jss/lib/backends/VirtualRenderer';
 import preset from 'jss-preset-default';
 import { stripIndent } from 'common-tags';
 import { createStyleManager, createStyleSheet } from 'src';
+import createDOM from 'test/dom';
 
 describe('ssr', () => {
-  let styleManager;
-  let buttonSheet;
-  let iconSheet;
+  describe('rendering to a string', () => {
+    let styleManager;
+    let buttonSheet;
+    let iconSheet;
 
-  beforeEach(() => {
-    styleManager = createStyleManager({
-      jss: createJss(preset()),
+    beforeEach(() => {
+      styleManager = createStyleManager({
+        jss: createJss(preset()),
+      });
+
+      buttonSheet = createStyleSheet('button', {
+        root: {
+          color: 'red',
+        },
+      });
+
+      iconSheet = createStyleSheet('icon', {
+        root: {
+          color: 'blue',
+        },
+      });
     });
 
-    buttonSheet = createStyleSheet('button', {
-      root: {
-        color: 'red',
-      },
-    }, { Renderer: VirtualRenderer });
+    it('should render the sheets to a string in order', () => {
+      styleManager.setSheetOrder(['icon', 'button']);
 
-    iconSheet = createStyleSheet('icon', {
-      root: {
-        color: 'blue',
-      },
-    }, { Renderer: VirtualRenderer });
+      styleManager.render(buttonSheet);
+      styleManager.render(iconSheet);
+
+      const styles = styleManager.sheetsToString();
+
+      assert.strictEqual(
+        styles,
+        stripIndent`
+          .icon-root-1243194637 {
+            color: blue;
+          }
+          .button-root-3645560457 {
+            color: red;
+          }
+        `,
+      );
+    });
+
+    it('should render the sheets to a string in a different order', () => {
+      styleManager.setSheetOrder(['button', 'icon']);
+
+      styleManager.render(buttonSheet);
+      styleManager.render(iconSheet);
+
+      const styles = styleManager.sheetsToString();
+      assert.strictEqual(
+        styles,
+        stripIndent`
+          .button-root-3645560457 {
+            color: red;
+          }
+          .icon-root-1243194637 {
+            color: blue;
+          }
+        `,
+      );
+    });
   });
 
-  it('should render the sheets to a string in order', () => {
-    styleManager.setSheetOrder(['icon', 'button']);
+  describe('taking over existing style nodes on the client', () => {
+    let dom;
+    let styleNode;
+    let styleSheet;
+    let styleManager;
 
-    styleManager.render(buttonSheet);
-    styleManager.render(iconSheet);
+    function createStyleNode(name) {
+      const element = document.createElement('style');
+      element.setAttribute('data-jss', '');
+      element.setAttribute('data-meta', name);
+      return element;
+    }
 
-    const styles = styleManager.sheetsToString();
+    beforeEach(() => {
+      dom = createDOM();
+      styleManager = createStyleManager({
+        jss: createJss(preset()),
+      });
+      styleSheet = createStyleSheet('foo', { woof: { color: 'red' } });
 
-    assert.strictEqual(
-      styles,
-      stripIndent`
-        .icon-root-1243194637 {
-          color: blue;
-        }
-        .button-root-3645560457 {
-          color: red;
-        }
-      `,
-    );
-  });
+      document.head.appendChild(createStyleNode('fizz'));
+      styleNode = createStyleNode('foo');
+      document.head.appendChild(styleNode);
+      document.head.appendChild(createStyleNode('bar'));
+      document.head.appendChild(createStyleNode('buzz'));
+    });
 
-  it('should render the sheets to a string in a different order', () => {
-    styleManager.setSheetOrder(['button', 'icon']);
+    afterEach(() => {
+      dom.destroy();
+    });
 
-    styleManager.render(buttonSheet);
-    styleManager.render(iconSheet);
-
-    const styles = styleManager.sheetsToString();
-    assert.strictEqual(
-      styles,
-      stripIndent`
-        .button-root-3645560457 {
-          color: red;
-        }
-        .icon-root-1243194637 {
-          color: blue;
-        }
-      `,
-    );
+    it('should re-use the existing style node', () => {
+      styleManager.render(styleSheet);
+      assert.strictEqual(
+        styleManager.sheetMap[0].jssStyleSheet.options.element,
+        styleNode,
+      );
+      assert.strictEqual(document.head.querySelectorAll('style').length, 4);
+    });
   });
 });


### PR DESCRIPTION
This is to fix both SSR and some HMR issues.

It does this by detecting existing style nodes on initialization to use. To better identify, the theme is now being hashed and added to the sheet meta value.