### PR TITLE
Keep the theme hash constant

### DIFF
--- a/src/styleManager.js
+++ b/src/styleManager.js
@@ -19,8 +19,8 @@ export function createStyleManager({ jss, theme = {} }: StyleManagerOptions = {}
   // Register custom jss generateClassName function
   jss.options.generateClassName = generateClassName;
 
+  const hash = createHash(theme.id);
   function generateClassName(str: string, rule: Object): string {
-    const hash = createHash(str);
     str = rule.name ? `${rule.name}-${hash}` : hash;
 
     // Simplify after next release with new method signature

--- a/src/styleManager.js
+++ b/src/styleManager.js
@@ -19,8 +19,9 @@ export function createStyleManager({ jss, theme = {} }: StyleManagerOptions = {}
   // Register custom jss generateClassName function
   jss.options.generateClassName = generateClassName;
 
-  const hash = createHash(theme.id);
+  
   function generateClassName(str: string, rule: Object): string {
+    const hash = createHash(theme.id);
     str = rule.name ? `${rule.name}-${hash}` : hash;
 
     // Simplify after next release with new method signature


### PR DESCRIPTION
This change allows you to update the theme and not need to update all the class names on the page for the new styles to apply.

Now when you apply the below code any css using the 'primaryColour' prop will update on the screen.
```js
styleManager.updateTheme({
  primaryColour: 'red',
})
```

Before, all the style sheets would end up being removed and then when a new style sheet is added the existing class names won't match up because the hash changes.