### PR TITLE
Bump JSS to ^8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "url": "https://github.com/nathanmarks/jss-theme-reactor/issues"
   },
   "dependencies": {
-    "jss": "^7.0.3",
-    "jss-preset-default": "^2.0.0",
-    "jss-vendor-prefixer": "^5.1.0",
+    "jss": "^8.1.0",
+    "jss-preset-default": "^3.0.0",
+    "jss-vendor-prefixer": "^6.0.0",
     "murmurhash-js": "^1.0.0"
   },
   "devDependencies": {

--- a/src/ThemeProvider.js
+++ b/src/ThemeProvider.js
@@ -27,7 +27,7 @@ export const defaultJssOptions = Object.assign({}, jssPreset(), {
 
 export function createThemeProvider(
   createDefaultTheme: () => Object = (): Object => ({}),
-  createJss: () => Jss = (): Jss => create(defaultJssOptions)
+  createJss: () => Jss = (): Jss => create(defaultJssOptions),
 ) {
   class ThemeProvider extends Component {
     static propTypes = {

--- a/src/ThemeProvider.js
+++ b/src/ThemeProvider.js
@@ -5,9 +5,29 @@ import { create } from 'jss';
 import jssPreset from 'jss-preset-default';
 import { createStyleManager } from './styleManager';
 
+const createGenerateClassName = () => {
+  let ruleCounter: number = 0;
+  return function generateClassName(rule: Object, sheet: Object): string {
+    let str: string = '';
+
+    ruleCounter += 1;
+    str = rule.key ? `${rule.key}-tr-${ruleCounter}` : `tr-${ruleCounter}`;
+
+    // Simplify after next release with new method signature
+    if (sheet && sheet.options.name) {
+      return `${sheet.options.name}-${str}`;
+    }
+    return str;
+  };
+};
+
+export const defaultJssOptions = Object.assign({}, jssPreset(), {
+  createGenerateClassName,
+});
+
 export function createThemeProvider(
   createDefaultTheme: () => Object = (): Object => ({}),
-  createJss: () => Jss = (): Jss => create(jssPreset()),
+  createJss: () => Jss = (): Jss => create(defaultJssOptions)
 ) {
   class ThemeProvider extends Component {
     static propTypes = {

--- a/src/styleManager.js
+++ b/src/styleManager.js
@@ -16,24 +16,6 @@ export function createStyleManager({ jss, theme = {} }: StyleManagerOptions = {}
   let sheetMap: Array<SheetMapping> = [];
   let sheetOrder: Array<string>;
 
-  // Register custom jss generateClassName function
-  jss.options.generateClassName = generateClassName;
-
-  let ruleCounter: number = 0;
-
-  function generateClassName(rule: Object, sheet: Object): string {
-    let str: string = '';
-
-    ruleCounter += 1;
-    str = rule.name ? `${rule.name}-tr-${ruleCounter}` : `tr-${ruleCounter}`;
-
-    // Simplify after next release with new method signature
-    if (sheet && sheet.options.name) {
-      return `${sheet.options.name}-${str}`;
-    }
-    return str;
-  }
-
   /**
    * styleManager
    */

--- a/test/fixtures/Button.js
+++ b/test/fixtures/Button.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import DomRenderer from 'jss/lib/backends/DomRenderer';
+import DomRenderer from 'jss/lib/renderers/DomRenderer';
 import { createStyleSheet } from 'src';
 
 const styleSheet = createStyleSheet('button', (theme) => ({

--- a/test/integration/basicUsage.test.js
+++ b/test/integration/basicUsage.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { create as createJss } from 'jss';
 import DomRenderer from 'jss/lib/renderers/DomRenderer';
 import { createStyleManager, createStyleSheet } from 'src';
-import { defaultJssOptions } from '../../src/ThemeProvider'
+import { defaultJssOptions } from '../../src/ThemeProvider';
 
 describe('basic usage', () => {
   let themeObj;

--- a/test/integration/basicUsage.test.js
+++ b/test/integration/basicUsage.test.js
@@ -2,8 +2,8 @@
 import { assert } from 'chai';
 import { create as createJss } from 'jss';
 import DomRenderer from 'jss/lib/renderers/DomRenderer';
-import preset from 'jss-preset-default';
 import { createStyleManager, createStyleSheet } from 'src';
+import { defaultJssOptions } from '../../src/ThemeProvider'
 
 describe('basic usage', () => {
   let themeObj;
@@ -18,7 +18,7 @@ describe('basic usage', () => {
       color: 'red',
     };
     styleManager = createStyleManager({
-      jss: createJss(preset()),
+      jss: createJss(defaultJssOptions),
       theme: themeObj,
     });
     styleSheet = createStyleSheet('button', (theme) => ({

--- a/test/integration/basicUsage.test.js
+++ b/test/integration/basicUsage.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import { assert } from 'chai';
 import { create as createJss } from 'jss';
-import DomRenderer from 'jss/lib/backends/DomRenderer';
+import DomRenderer from 'jss/lib/renderers/DomRenderer';
 import preset from 'jss-preset-default';
 import { createStyleManager, createStyleSheet } from 'src';
 

--- a/test/integration/ssr.test.js
+++ b/test/integration/ssr.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 import { assert } from 'chai';
 import { create as createJss } from 'jss';
-import preset from 'jss-preset-default';
 import { stripIndent } from 'common-tags';
 import { createStyleManager, createStyleSheet } from 'src';
+import { defaultJssOptions } from '../../src/ThemeProvider';
 
 describe('ssr', () => {
   describe('rendering to a string', () => {
@@ -13,7 +13,7 @@ describe('ssr', () => {
 
     beforeEach(() => {
       styleManager = createStyleManager({
-        jss: createJss(preset()),
+        jss: createJss(defaultJssOptions),
       });
 
       buttonSheet = createStyleSheet('button', {
@@ -89,7 +89,7 @@ describe('ssr', () => {
 
     beforeEach(() => {
       styleManager = createStyleManager({
-        jss: createJss(preset()),
+        jss: createJss(defaultJssOptions),
       });
       styleSheet = createStyleSheet('foo', { woof: { color: 'red' } });
 

--- a/test/integration/themeUpdate.test.js
+++ b/test/integration/themeUpdate.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import { assert } from 'chai';
 import { create as createJss } from 'jss';
-import DomRenderer from 'jss/lib/backends/DomRenderer';
+import DomRenderer from 'jss/lib/renderers/DomRenderer';
 import preset from 'jss-preset-default';
 import { createStyleManager, createStyleSheet } from 'src';
 

--- a/test/integration/themeUpdate.test.js
+++ b/test/integration/themeUpdate.test.js
@@ -2,8 +2,8 @@
 import { assert } from 'chai';
 import { create as createJss } from 'jss';
 import DomRenderer from 'jss/lib/renderers/DomRenderer';
-import preset from 'jss-preset-default';
 import { createStyleManager, createStyleSheet } from 'src';
+import { defaultJssOptions } from '../../src/ThemeProvider';
 
 describe('theme update', () => {
   let themeObj;
@@ -23,7 +23,7 @@ describe('theme update', () => {
       color: 'blue',
     };
     styleManager = createStyleManager({
-      jss: createJss(preset()),
+      jss: createJss(defaultJssOptions),
       theme: themeObj,
     });
     styleSheet = createStyleSheet('button', (theme) => ({


### PR DESCRIPTION
Also fixed breaking changes from migration between 7.1.7 to 8.1.0 https://github.com/cssinjs/jss/blob/v8.1.0/changelog.md#800--2017-06-20

breaking changes were:

* moved  DOM renderer
* deprecation of generateClassName option in jss.createStylesheet, now you have to provide createGenerateClassName factory when you create jss